### PR TITLE
chore: bump python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "synapse-invite-policies"
 description = 'Synapse module which allows restricting invite permissions'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10.0,<4.0.0"
 license = "AGPL-3.0-only"
 keywords = []
 authors = [


### PR DESCRIPTION
use the same requirement as for synapse

SYN-25