### PR TITLE
chore: update GitHub Action pins

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           path: head
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -40,7 +40,7 @@ jobs:
           python -m pip install hatch
 
       - name: Formatting
-        uses: famedly/black@stable
+        uses: famedly/black@6af7d1109693c4ad3af08ecbc34649c232b47a6d
         with:
           src: head
           options: "--check --verbose"
@@ -50,7 +50,7 @@ jobs:
         run: echo PYTHON_TARGET="py${{ matrix.python-version }}" | sed -r "s/\.//" >> $GITHUB_ENV
 
       - name: Lint
-        uses: chartboost/ruff-action@2bc585f1253832f5a5220d7fbf86976822116147
+        uses: chartboost/ruff-action@1ec810db51b3ebdd902c812e962d2f7aafe85fcf
         with:
           args: --target-version ${{ env.PYTHON_TARGET }}
           src: head
@@ -62,13 +62,13 @@ jobs:
       - name: Load base coverage results from cache
         if: github.event_name == 'pull_request'
         id: cache-coverage
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ./base.lcov
           key: coverage-${{ github.event.pull_request.base.sha }}
 
       - name: Pull base
-        uses: actions/checkout@v3
+        uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
         if: github.event_name == 'pull_request' && steps.cache-coverage.outputs.cache-hit != 'true'
         with:
           ref: ${{ github.event.pull_request.base.ref }}
@@ -85,7 +85,7 @@ jobs:
       - name: Meow Coverage
         id: coverage-report
         continue-on-error: true
-        uses: famedly/meow-coverage@main
+        uses: famedly/meow-coverage@ead50e2b41ca1c2f47b9367b374e588ac8a419d9
         if: github.event_name == 'pull_request'
         with:
           new-lcov-file: 'head.lcov'


### PR DESCRIPTION
## Summary
- Pin all external GitHub Actions in workflows to current upstream default-branch commit SHAs.
- Includes actions discovered from every `uses:` entry in `.github/**/*.yml` and `.github/**/*.yaml`.

## Verification
- Commit is GPG-signed locally.
- CI on this PR should validate the updated action refs.